### PR TITLE
update deprecated runtime

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ async function build({
   const output = await createLambda({
     files: { ...extraFiles, ...(await glob('**', distPath)) },
     handler: 'bootstrap',
-    runtime: 'provided',
+    runtime: 'provided.al2023',
   })
 
   return { output }


### PR DESCRIPTION
[AWS will soon deprecate the AL2 runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported), Vercel already[ deprecated Node 18 and with that the AL2 runtime](https://vercel.com/changelog/node-js-18-is-being-deprecated).

You can read about the Build image more here: https://vercel.com/docs/builds/build-image